### PR TITLE
feat: add evaluate_mappings utility for taxonomy mapping quality assessment

### DIFF
--- a/docs/examples/notebooks/Evaluate_taxonomy_mappings.ipynb
+++ b/docs/examples/notebooks/Evaluate_taxonomy_mappings.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating taxonomy mappings\n",
+    "\n",
+    "## Goal: measure the quality of proposed mappings against curated mappings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "The risk mapper proposes cross-taxonomy mappings, either with the `SEMANTIC` method (embedding similarity) or the `INFERENCE` method (an LLM). These are suggestions that are meant to be reviewed by a human.\n",
+    "\n",
+    "This notebook measures how good those suggestions are, by scoring them against the curated (human-reviewed) mappings that already ship in the repo. Running it gives a baseline that can be re-run after changes to quantify whether the mapping suggestions have improved.\n",
+    "\n",
+    "We look at two things:\n",
+    "\n",
+    "- **Retrieval**: for a given risk, did the mapper find the same related risks that a human curator had already linked it to? Reported as precision, recall and F1 on the risk pairs, ignoring direction.\n",
+    "- **Coverage**: for how many curated source risks did the mapper recover at least one of their curated mappings?\n",
+    "\n",
+    "The example maps the IBM Risk Atlas onto the MIT AI Risk Repository. Only mappings marked `ManualMappingCuration` are used as ground truth, so the mapper is not scored against other machine-generated mappings.\n",
+    "\n",
+    "One important detail: the MIT repository ships two kinds of entries. Its **domain** taxonomy holds actual risks, while its **causal** taxonomy holds classification factors (entity: AI / Human, intent: Intentional / Unintentional, timing: Pre- / Post-deployment). Those causal factors are not risks, and a risk-to-risk mapper is not meant to produce them, so we evaluate against the domain risks only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "81ca4f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ai_atlas_nexus import AIAtlasNexus\n",
+    "from ai_atlas_nexus.blocks.risk_mapping import (\n",
+    "    evaluate_mappings,\n",
+    "    load_curated_mappings,\n",
+    ")\n",
+    "from ai_atlas_nexus.metadata_base import MappingMethod"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df8bcf71",
+   "metadata": {},
+   "source": [
+    "## Load the risks\n",
+    "\n",
+    "We load the IBM Risk Atlas risks and the MIT AI Risk Repository **domain** risks (the causal classification factors are excluded, as explained above)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9c71401e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2026-08-07 19:08:33:788] - INFO - AIAtlasNexus - Created AIAtlasNexus instance. Base_dir: None\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(99, 24)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nexus = AIAtlasNexus()\n",
+    "\n",
+    "ibm_risks = nexus.get_all_risks(taxonomy=\"ibm-risk-atlas\")\n",
+    "mit_risks = nexus.get_all_risks(taxonomy=\"mit-ai-risk-repository\")\n",
+    "\n",
+    "len(ibm_risks), len(mit_risks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7ac525d",
+   "metadata": {},
+   "source": [
+    "## Generate the proposed mappings\n",
+    "\n",
+    "We map each IBM risk onto the MIT domain risks with the `SEMANTIC` method. This method is deterministic and needs no LLM, so the baseline is stable and reproducible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0c0bce20",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c50a092f9d5a403c9696e27a649b22f5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/199 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2026-08-07 19:09:37:333] - INFO - AIAtlasNexus - No match found for atlas-personal-information-in-prompt (best similarity 0.498)\n",
+      "[2026-08-07 19:09:39:588] - INFO - AIAtlasNexus - No match found for atlas-data-provenance (best similarity 0.489)\n",
+      "[2026-08-07 19:09:41:515] - INFO - AIAtlasNexus - No match found for atlas-copyright-infringement (best similarity 0.469)\n",
+      "[2026-08-07 19:09:43:308] - INFO - AIAtlasNexus - No match found for atlas-model-usage-rights (best similarity 0.406)\n",
+      "[2026-08-07 19:09:44:652] - INFO - AIAtlasNexus - No match found for atlas-improper-usage (best similarity 0.462)\n",
+      "[2026-08-07 19:09:45:18] - INFO - AIAtlasNexus - No match found for atlas-jailbreaking (best similarity 0.421)\n",
+      "[2026-08-07 19:09:46:36] - INFO - AIAtlasNexus - No match found for atlas-data-transfer (best similarity 0.477)\n",
+      "[2026-08-07 19:09:47:821] - INFO - AIAtlasNexus - No match found for atlas-temporal-gap (best similarity 0.482)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "91"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predicted = nexus.generate_proposed_mappings(\n",
+    "    new_risks=ibm_risks,\n",
+    "    existing_risks=mit_risks,\n",
+    "    inference_engine=None,\n",
+    "    new_prefix=\"ibm-risk-atlas\",\n",
+    "    mapping_method=MappingMethod.SEMANTIC,\n",
+    ")\n",
+    "\n",
+    "len(predicted)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4fab2b4",
+   "metadata": {},
+   "source": [
+    "## Load the curated ground truth\n",
+    "\n",
+    "`load_curated_mappings` reads the shipped mapping file, keeps only the manually curated rows, and drops any `noMatch` rows. We then keep only the mappings to actual MIT risks, so the causal classification factors are not counted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a0e03494",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Not propagating value for 'mapping_date' because the slot is already set on individual records.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "63"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ground_truth = load_curated_mappings(\n",
+    "    \"mit-ai-risk-repository_ibm-risk-atlas.tsv\"\n",
+    ")\n",
+    "\n",
+    "mit_ids = {risk.id for risk in mit_risks}\n",
+    "ground_truth = [\n",
+    "    m for m in ground_truth if str(m.object_id).split(\":\")[-1] in mit_ids\n",
+    "]\n",
+    "\n",
+    "len(ground_truth)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "142e1a1c",
+   "metadata": {},
+   "source": [
+    "## Evaluate\n",
+    "\n",
+    "`evaluate_mappings` compares the predicted mappings against the ground truth and returns the retrieval and coverage metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5a459c2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"retrieval\": {\n",
+      "    \"precision\": 0.3187,\n",
+      "    \"recall\": 0.4754,\n",
+      "    \"f1\": 0.3816,\n",
+      "    \"n_predicted_pairs\": 91,\n",
+      "    \"n_ground_truth_pairs\": 61,\n",
+      "    \"n_matched_pairs\": 29\n",
+      "  },\n",
+      "  \"coverage\": {\n",
+      "    \"source_risk_coverage\": 0.4754,\n",
+      "    \"n_source_risks\": 61,\n",
+      "    \"n_source_risks_covered\": 29\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "report = evaluate_mappings(predicted, ground_truth)\n",
+    "print(json.dumps(report, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed1b232c",
+   "metadata": {},
+   "source": [
+    "## Baseline results\n",
+    "\n",
+    "Running the above with the `SEMANTIC` method gives the following baseline:\n",
+    "\n",
+    "| Metric | Value |\n",
+    "| --- | --- |\n",
+    "| Precision | 0.3187 |\n",
+    "| Recall | 0.4754 |\n",
+    "| F1 | 0.3816 |\n",
+    "| Source-risk coverage | 0.4754 |\n",
+    "\n",
+    "From 91 proposed mappings, the mapper recovered 29 of the 61 curated risk-to-risk pairs, covering 29 of the 61 curated source risks.\n",
+    "\n",
+    "Recall and coverage are the reliable signals here: from a single top match per risk, the embedding method recovers close to half of the curated risk-to-risk mappings. Precision reads lower because the mapper proposes a match for every risk while the curated set only records some pairs, so a proposed pair that a curator did not record still counts against precision even when it is plausible."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "v-ai-atlas-nexus (3.12.0.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/ai_atlas_nexus/blocks/risk_mapping/__init__.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/__init__.py
@@ -1,3 +1,3 @@
 from .base import RiskMappingBase
-from .evaluation import evaluate_mappings
+from .evaluation import evaluate_mappings, load_curated_mappings
 from .risk_mapper import RiskMapper

--- a/src/ai_atlas_nexus/blocks/risk_mapping/__init__.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/__init__.py
@@ -1,2 +1,3 @@
 from .base import RiskMappingBase
+from .evaluation import evaluate_mappings
 from .risk_mapper import RiskMapper

--- a/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
@@ -68,7 +68,10 @@ def evaluate_mappings(predicted: list[Mapping], ground_truth: list[Mapping]) -> 
     Returns:
         dict: retrieval metrics (precision, recall, F1 on risk pairs, with
         counts) and coverage (the fraction of ground-truth source risks for
-        which at least one curated mapping was recovered).
+        which at least one curated mapping was recovered). A metric is
+        ``None`` when it is not applicable, e.g. precision when nothing was
+        predicted, which is different from a real ``0.0`` (something was
+        predicted and none of it was correct).
     """
     predicted_pairs = {_pair_key(m) for m in predicted}
     ground_truth_pairs = {_pair_key(m) for m in ground_truth}
@@ -78,9 +81,12 @@ def evaluate_mappings(predicted: list[Mapping], ground_truth: list[Mapping]) -> 
     n_ground_truth = len(ground_truth_pairs)
     n_matched = len(matched_pairs)
 
-    precision = n_matched / n_predicted if n_predicted else 0.0
-    recall = n_matched / n_ground_truth if n_ground_truth else 0.0
-    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    precision = n_matched / n_predicted if n_predicted else None
+    recall = n_matched / n_ground_truth if n_ground_truth else None
+    if precision is None or recall is None:
+        f1 = None
+    else:
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
 
     # Coverage: for how many curated source risks did we recover at least one of
     # their curated mappings? This is more informative than pair recall when a
@@ -92,19 +98,19 @@ def evaluate_mappings(predicted: list[Mapping], ground_truth: list[Mapping]) -> 
 
     covered = sum(1 for pairs in pairs_by_source.values() if pairs & predicted_pairs)
     n_sources = len(pairs_by_source)
-    source_coverage = covered / n_sources if n_sources else 0.0
+    source_coverage = covered / n_sources if n_sources else None
 
     return {
         "retrieval": {
-            "precision": round(precision, 4),
-            "recall": round(recall, 4),
-            "f1": round(f1, 4),
+            "precision": round(precision, 4) if precision is not None else None,
+            "recall": round(recall, 4) if recall is not None else None,
+            "f1": round(f1, 4) if f1 is not None else None,
             "n_predicted_pairs": n_predicted,
             "n_ground_truth_pairs": n_ground_truth,
             "n_matched_pairs": n_matched,
         },
         "coverage": {
-            "source_risk_coverage": round(source_coverage, 4),
+            "source_risk_coverage": round(source_coverage, 4) if source_coverage is not None else None,
             "n_source_risks": n_sources,
             "n_source_risks_covered": covered,
         },

--- a/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
@@ -1,0 +1,78 @@
+"""Evaluate proposed cross-taxonomy mappings against curated ground truth.
+
+The risk mapper produces suggested mappings between taxonomies. This utility
+scores those suggestions against a set of curated (human-reviewed) mappings so
+we can establish a baseline and re-run the same measurement after changes.
+"""
+
+from sssom_schema import Mapping
+
+
+def _pair_key(mapping: Mapping) -> tuple:
+    """Return a direction-agnostic key for a mapping.
+
+    Ids are stored as CURIEs (e.g. ``ibm-risk-atlas:atlas-x``). We compare on
+    the local part after the prefix, and sort the two ids so that a mapping and
+    its reverse are treated as the same pair.
+    """
+    subject = str(mapping.subject_id).split(":")[-1]
+    obj = str(mapping.object_id).split(":")[-1]
+    return tuple(sorted((subject, obj)))
+
+
+def evaluate_mappings(predicted: list[Mapping], ground_truth: list[Mapping]) -> dict:
+    """Score predicted mappings against curated ground-truth mappings.
+
+    Matching is on the risk pair only (direction-agnostic) and ignores the
+    predicate, which keeps this focused on retrieval and coverage.
+
+    Args:
+        predicted: list[Mapping]
+            Mappings produced by the risk mapper.
+        ground_truth: list[Mapping]
+            Curated mappings to score against.
+
+    Returns:
+        dict: retrieval metrics (precision, recall, F1 on risk pairs, with
+        counts) and coverage (the fraction of ground-truth source risks for
+        which at least one curated mapping was recovered).
+    """
+    predicted_pairs = {_pair_key(m) for m in predicted}
+    ground_truth_pairs = {_pair_key(m) for m in ground_truth}
+    matched_pairs = predicted_pairs & ground_truth_pairs
+
+    n_predicted = len(predicted_pairs)
+    n_ground_truth = len(ground_truth_pairs)
+    n_matched = len(matched_pairs)
+
+    precision = n_matched / n_predicted if n_predicted else 0.0
+    recall = n_matched / n_ground_truth if n_ground_truth else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    # Coverage: for how many curated source risks did we recover at least one of
+    # their curated mappings? This is more informative than pair recall when a
+    # source risk has several curated targets but the mapper returns one match.
+    pairs_by_source: dict = {}
+    for mapping in ground_truth:
+        source = str(mapping.subject_id).split(":")[-1]
+        pairs_by_source.setdefault(source, set()).add(_pair_key(mapping))
+
+    covered = sum(1 for pairs in pairs_by_source.values() if pairs & predicted_pairs)
+    n_sources = len(pairs_by_source)
+    source_coverage = covered / n_sources if n_sources else 0.0
+
+    return {
+        "retrieval": {
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
+            "n_predicted_pairs": n_predicted,
+            "n_ground_truth_pairs": n_ground_truth,
+            "n_matched_pairs": n_matched,
+        },
+        "coverage": {
+            "source_risk_coverage": round(source_coverage, 4),
+            "n_source_risks": n_sources,
+            "n_source_risks_covered": covered,
+        },
+    }

--- a/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
@@ -15,7 +15,9 @@ _MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "data" / "mappings"
 
 
 def load_curated_mappings(
-    filename: str, justification: str = "semapv:ManualMappingCuration"
+    filename: str,
+    justification: str = "semapv:ManualMappingCuration",
+    risk_ids: set[str] | None = None,
 ) -> list[Mapping]:
     """Load curated mappings from a shipped SSSOM/TSV file, for use as ground truth.
 
@@ -26,6 +28,10 @@ def load_curated_mappings(
             Keep only mappings with this mapping_justification. Defaults to
             manual curation so the mapper is not scored against machine-generated
             mappings, which would be circular.
+        risk_ids: set[str], optional
+            If given, keep only mappings where both subject and object are risk
+            ids in this set. Excludes non-risk targets, e.g. classification
+            factors or requirements, that some curated files also mix in.
 
     Returns:
         list[Mapping]: the curated mappings, with noMatch rows removed.
@@ -34,11 +40,19 @@ def load_curated_mappings(
 
     path = _MAPPINGS_DIR / filename
     mapping_set = parse_sssom_table(file_path=str(path)).to_mapping_set()
-    return [
+    mappings = [
         m
         for m in mapping_set.mappings
         if m.mapping_justification == justification and m.predicate_id != "noMatch"
     ]
+    if risk_ids is not None:
+        mappings = [
+            m
+            for m in mappings
+            if str(m.subject_id).split(":")[-1] in risk_ids
+            and str(m.object_id).split(":")[-1] in risk_ids
+        ]
+    return mappings
 
 
 def _pair_key(mapping: Mapping) -> tuple:

--- a/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
+++ b/src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py
@@ -5,7 +5,40 @@ scores those suggestions against a set of curated (human-reviewed) mappings so
 we can establish a baseline and re-run the same measurement after changes.
 """
 
+from pathlib import Path
+
 from sssom_schema import Mapping
+
+
+# Curated mapping files ship in the package data directory.
+_MAPPINGS_DIR = Path(__file__).resolve().parents[2] / "data" / "mappings"
+
+
+def load_curated_mappings(
+    filename: str, justification: str = "semapv:ManualMappingCuration"
+) -> list[Mapping]:
+    """Load curated mappings from a shipped SSSOM/TSV file, for use as ground truth.
+
+    Args:
+        filename: str
+            Name of a mapping file in the package's data/mappings directory.
+        justification: str
+            Keep only mappings with this mapping_justification. Defaults to
+            manual curation so the mapper is not scored against machine-generated
+            mappings, which would be circular.
+
+    Returns:
+        list[Mapping]: the curated mappings, with noMatch rows removed.
+    """
+    from sssom.parsers import parse_sssom_table
+
+    path = _MAPPINGS_DIR / filename
+    mapping_set = parse_sssom_table(file_path=str(path)).to_mapping_set()
+    return [
+        m
+        for m in mapping_set.mappings
+        if m.mapping_justification == justification and m.predicate_id != "noMatch"
+    ]
 
 
 def _pair_key(mapping: Mapping) -> tuple:

--- a/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
+++ b/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
@@ -125,3 +125,17 @@ class TestLoadCuratedMappings:
         mappings = load_curated_mappings("ibm2owasp.tsv")
         assert mappings  # file has manual rows
         assert all(m.predicate_id != "noMatch" for m in mappings)
+
+    def test_risk_ids_filters_out_non_risk_targets(self):
+        # this subject also maps to MIT causal factors (not risks), which
+        # must be dropped when risk_ids only lists the real risk on both sides
+        risk_ids = {"atlas-attribute-inference-attack", "mit-ai-risk-subdomain-2.2"}
+        mappings = load_curated_mappings(
+            "mit-ai-risk-repository_ibm-risk-atlas.tsv", risk_ids=risk_ids
+        )
+        assert mappings
+        assert all(
+            str(m.subject_id).split(":")[-1] in risk_ids
+            and str(m.object_id).split(":")[-1] in risk_ids
+            for m in mappings
+        )

--- a/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
+++ b/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
@@ -2,7 +2,7 @@
 
 from sssom_schema import Mapping
 
-from ai_atlas_nexus.blocks.risk_mapping import evaluate_mappings
+from ai_atlas_nexus.blocks.risk_mapping import evaluate_mappings, load_curated_mappings
 
 
 def _m(subject, obj, predicate="skos:relatedMatch"):
@@ -93,3 +93,24 @@ class TestCoverage:
         cov = evaluate_mappings([_m("ibm:a", "mit:x")], [])["coverage"]
         assert cov["source_risk_coverage"] == 0.0
         assert cov["n_source_risks"] == 0
+
+
+class TestLoadCuratedMappings:
+    """Loading curated ground truth from the shipped SSSOM files."""
+
+    def test_loads_ibm_mit_manual_pairs(self):
+        mappings = load_curated_mappings("mit-ai-risk-repository_ibm-risk-atlas.tsv")
+        assert len(mappings) == 252
+        assert all(
+            m.mapping_justification == "semapv:ManualMappingCuration" for m in mappings
+        )
+        assert all(m.subject_id and m.object_id for m in mappings)
+
+    def test_default_keeps_only_manual_curation(self):
+        # ailuminate is entirely LLM/similarity generated, so nothing is manual
+        assert load_curated_mappings("ailuminate-v1.0.sssom.tsv") == []
+
+    def test_drops_no_match_rows(self):
+        mappings = load_curated_mappings("ibm2owasp.tsv")
+        assert mappings  # file has manual rows
+        assert all(m.predicate_id != "noMatch" for m in mappings)

--- a/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
+++ b/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
@@ -1,0 +1,95 @@
+"""Tests for evaluate_mappings (mapping-quality metrics)."""
+
+from sssom_schema import Mapping
+
+from ai_atlas_nexus.blocks.risk_mapping import evaluate_mappings
+
+
+def _m(subject, obj, predicate="skos:relatedMatch"):
+    return Mapping(
+        subject_id=subject,
+        predicate_id=predicate,
+        object_id=obj,
+        mapping_justification="semapv:ManualMappingCuration",
+    )
+
+
+class TestRetrieval:
+
+    def test_perfect_match(self):
+        gt = [_m("ibm:a", "mit:x"), _m("ibm:b", "mit:y")]
+        pred = [_m("ibm:a", "mit:x"), _m("ibm:b", "mit:y")]
+        r = evaluate_mappings(pred, gt)["retrieval"]
+        assert r["precision"] == 1.0
+        assert r["recall"] == 1.0
+        assert r["f1"] == 1.0
+        assert r["n_matched_pairs"] == 2
+
+    def test_partial_overlap(self):
+        gt = [_m("ibm:a", "mit:x"), _m("ibm:b", "mit:y")]
+        pred = [_m("ibm:a", "mit:x"), _m("ibm:c", "mit:z")]  # 1 right, 1 wrong
+        r = evaluate_mappings(pred, gt)["retrieval"]
+        assert r["precision"] == 0.5  # 1 of 2 predicted correct
+        assert r["recall"] == 0.5  # 1 of 2 ground truth found
+        assert r["f1"] == 0.5
+
+    def test_direction_agnostic(self):
+        # ground truth ibm->mit, prediction mit->ibm: same pair
+        gt = [_m("ibm-risk-atlas:a", "mit-ai-risk-repository:x")]
+        pred = [_m("mit-ai-risk-repository:x", "ibm-risk-atlas:a")]
+        r = evaluate_mappings(pred, gt)["retrieval"]
+        assert r["n_matched_pairs"] == 1
+        assert r["recall"] == 1.0
+
+    def test_curie_prefixes_ignored(self):
+        # same local ids, different prefixes still match
+        gt = [_m("ibmairisk:atlas-x", "nistai:nist-y")]
+        pred = [_m("ibm-risk-atlas:atlas-x", "nist-ai-rmf:nist-y")]
+        assert evaluate_mappings(pred, gt)["retrieval"]["n_matched_pairs"] == 1
+
+    def test_duplicate_predictions_counted_once(self):
+        gt = [_m("ibm:a", "mit:x")]
+        pred = [_m("ibm:a", "mit:x"), _m("ibm:a", "mit:x")]
+        r = evaluate_mappings(pred, gt)["retrieval"]
+        assert r["n_predicted_pairs"] == 1
+        assert r["precision"] == 1.0
+
+    def test_empty_predicted(self):
+        gt = [_m("ibm:a", "mit:x")]
+        r = evaluate_mappings([], gt)["retrieval"]
+        assert r["precision"] == 0.0
+        assert r["recall"] == 0.0
+        assert r["f1"] == 0.0
+
+    def test_empty_ground_truth_does_not_divide_by_zero(self):
+        pred = [_m("ibm:a", "mit:x")]
+        r = evaluate_mappings(pred, [])["retrieval"]
+        assert r["recall"] == 0.0
+        assert r["precision"] == 0.0
+
+
+class TestCoverage:
+
+    def test_source_covered_when_one_of_several_targets_found(self):
+        # source "a" has 3 curated targets; mapper finds only 1 -> a is covered
+        gt = [_m("ibm:a", "mit:x"), _m("ibm:a", "mit:y"), _m("ibm:a", "mit:z")]
+        pred = [_m("ibm:a", "mit:y")]
+        result = evaluate_mappings(pred, gt)
+        assert result["coverage"]["source_risk_coverage"] == 1.0
+        assert result["coverage"]["n_source_risks"] == 1
+        assert result["coverage"]["n_source_risks_covered"] == 1
+        # but pair recall reflects the many-to-many gap
+        assert result["retrieval"]["recall"] == round(1 / 3, 4)
+
+    def test_partial_source_coverage(self):
+        gt = [_m("ibm:a", "mit:x"), _m("ibm:b", "mit:y")]
+        pred = [_m("ibm:a", "mit:x")]  # covers a, not b
+        cov = evaluate_mappings(pred, gt)["coverage"]
+        assert cov["n_source_risks"] == 2
+        assert cov["n_source_risks_covered"] == 1
+        assert cov["source_risk_coverage"] == 0.5
+
+    def test_no_ground_truth(self):
+        cov = evaluate_mappings([_m("ibm:a", "mit:x")], [])["coverage"]
+        assert cov["source_risk_coverage"] == 0.0
+        assert cov["n_source_risks"] == 0

--- a/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
+++ b/tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py
@@ -55,17 +55,20 @@ class TestRetrieval:
         assert r["precision"] == 1.0
 
     def test_empty_predicted(self):
+        # nothing predicted -> precision is not applicable, not a real 0.0
         gt = [_m("ibm:a", "mit:x")]
         r = evaluate_mappings([], gt)["retrieval"]
-        assert r["precision"] == 0.0
+        assert r["precision"] is None
         assert r["recall"] == 0.0
-        assert r["f1"] == 0.0
+        assert r["f1"] is None
 
     def test_empty_ground_truth_does_not_divide_by_zero(self):
+        # no ground truth -> recall is not applicable, not a real 0.0
         pred = [_m("ibm:a", "mit:x")]
         r = evaluate_mappings(pred, [])["retrieval"]
-        assert r["recall"] == 0.0
+        assert r["recall"] is None
         assert r["precision"] == 0.0
+        assert r["f1"] is None
 
 
 class TestCoverage:
@@ -90,8 +93,9 @@ class TestCoverage:
         assert cov["source_risk_coverage"] == 0.5
 
     def test_no_ground_truth(self):
+        # no ground-truth sources -> coverage is not applicable, not a real 0.0
         cov = evaluate_mappings([_m("ibm:a", "mit:x")], [])["coverage"]
-        assert cov["source_risk_coverage"] == 0.0
+        assert cov["source_risk_coverage"] is None
         assert cov["n_source_risks"] == 0
 
 
@@ -99,16 +103,23 @@ class TestLoadCuratedMappings:
     """Loading curated ground truth from the shipped SSSOM files."""
 
     def test_loads_ibm_mit_manual_pairs(self):
+        # exact row count isn't asserted, the file can grow as more mappings
+        # are curated; what must hold is that every row is manual and complete
         mappings = load_curated_mappings("mit-ai-risk-repository_ibm-risk-atlas.tsv")
-        assert len(mappings) == 252
+        assert mappings
         assert all(
             m.mapping_justification == "semapv:ManualMappingCuration" for m in mappings
         )
         assert all(m.subject_id and m.object_id for m in mappings)
 
     def test_default_keeps_only_manual_curation(self):
-        # ailuminate is entirely LLM/similarity generated, so nothing is manual
-        assert load_curated_mappings("ailuminate-v1.0.sssom.tsv") == []
+        # this file mixes ManualMappingCuration with SemanticSimilarityThresholdMatching,
+        # so this proves the filter both keeps manual rows and drops non-manual ones
+        mappings = load_curated_mappings("aiuc1_to_ibm_from_tsv_data.tsv")
+        assert mappings
+        assert all(
+            m.mapping_justification == "semapv:ManualMappingCuration" for m in mappings
+        )
 
     def test_drops_no_match_rows(self):
         mappings = load_curated_mappings("ibm2owasp.tsv")


### PR DESCRIPTION
## Status

**READY**

## Description

Adds a utility to evaluate the mappings produced by `generate_proposed_mappings`
against the curated mappings that already ship in the repo, so we can establish a
baseline and re-run the same measurement after changes.

Following the discussion on #236, this first version covers retrieval and
coverage for IBM Risk Atlas to MIT, and leaves the predicate task for later.

What is included:

- `evaluate_mappings(predicted, ground_truth)`: scores predicted mappings on
  retrieval (precision, recall, F1 on risk pairs, direction agnostic) and
  coverage (the fraction of curated source risks for which at least one curated
  mapping was recovered). Pure and deterministic.
- `load_curated_mappings(filename)`: loads curated ground truth from a shipped
  SSSOM file, keeping only `ManualMappingCuration` rows and dropping `noMatch`,
  so the mapper is not scored against machine-generated mappings.
- A notebook, `docs/examples/notebooks/Evaluate_taxonomy_mappings.ipynb`, that
  runs the baseline end to end and documents the result.

Closes: IBM/ai-atlas-nexus#236

Signed-off-by: Janam Patel <janamapatel@gmail.com>

## Impacted Areas in Application

- new `evaluate_mappings` and `load_curated_mappings` in `src/ai_atlas_nexus/blocks/risk_mapping/evaluation.py`
- exported from `src/ai_atlas_nexus/blocks/risk_mapping/__init__.py`
- new tests in `tests/ai_atlas_nexus/blocks/risk_mapping/test_evaluation.py`
- new notebook `docs/examples/notebooks/Evaluate_taxonomy_mappings.ipynb`

### Screenshots

Not applicable (python utility and notebook, no UI).

## Which issue(s) does this pull-request fix?

Closes: IBM/ai-atlas-nexus#236

## Any special notes for your reviewer?

**Baseline (SEMANTIC method, IBM Risk Atlas to MIT domain risks):**

| Metric | Value |
| --- | --- |
| Precision | 0.32 |
| Recall | 0.48 |
| F1 | 0.38 |
| Source-risk coverage | 0.48 |

From 91 proposed mappings, 29 of the 61 curated risk-to-risk pairs were
recovered. This is a zero-shot baseline for the existing embedding mapper, 
and it is the number future improvements can be measured against.

**A note on the MIT data.** The MIT repository ships a domain taxonomy (actual
risks) and a causal taxonomy (classification factors like Human / Intentional /
Post-deployment). The causal factors are not risks, so the evaluation scores against 
the domain risks only. Including the causal factors would unfairly deflate the numbers.

Also, I would value your input on:
1. `evaluate_mappings` returns a plain `dict`. I considered a small dataclass to
   make the fields explicit for the "diff across runs" use, but kept a dict for
   simplicity. Happy to switch if you prefer.

Tests are deterministic and need no LLM. They cover the metric maths (retrieval
and coverage, direction and prefix agnostic, empty and many-to-many cases) and
the loader (manual-only filtering, noMatch removal) against the real IBM to MIT
file. Full suite passes.

## Checklist

- [x] Automated tests exist
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local git lint performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided